### PR TITLE
Parameters for the transactions :order_id, :description, :merchant_name_descriptor, :merchant_location_descriptor

### DIFF
--- a/lib/spreedly-core-ruby/payment_method.rb
+++ b/lib/spreedly-core-ruby/payment_method.rb
@@ -128,6 +128,10 @@ module SpreedlyCore
           :amount => amount,
           :currency_code => currency,
           :ip => options[:ip_address],
+          :order_id => options[:order_id],
+          :description => options[:description],
+          :merchant_name_descriptor => options[:merchant_name_descriptor],
+          :merchant_location_descriptor => options[:merchant_location_descriptor], 
           :redirect_url => options[:redirect_url],
           :callback_url => options[:callback_url]
         }

--- a/lib/spreedly-core-ruby/transactions.rb
+++ b/lib/spreedly-core-ruby/transactions.rb
@@ -3,7 +3,8 @@ module SpreedlyCore
   class Transaction < Base
     attr_reader(:amount, :on_test_gateway, :created_at, :updated_at, :currency_code,
                 :succeeded, :token, :message, :transaction_type, :gateway_token,
-                :response, :signed, :state, :checkout_url)
+                :response, :signed, :state, :checkout_url, 
+                :order_id, :description, :merchant_name_descriptor, :merchant_location_descriptor)
     alias :succeeded? :succeeded
 
     # Breaks enacapsulation a bit, but allow subclasses to register the 'transaction_type'

--- a/test/test_factory.rb
+++ b/test/test_factory.rb
@@ -7,13 +7,25 @@ module SpreedlyCore
       payment_method
     end
   
-    def given_a_purchase(purchase_amount=100, ip_address='127.0.0.1')
+    def given_a_purchase(purchase_amount=100, ip_address='127.0.0.1', additional_options={})
+      default_additional_options = {:order_id => "123", :description => 'purchase description', :merchant_name_descriptor => 'merchant name', :merchant_location_descriptor => 'merchant location'}
+      options = default_additional_options.merge(additional_options)
+      options[:ip_address] = ip_address
+
       payment_method = given_a_payment_method
-      assert transaction = payment_method.purchase(purchase_amount, nil, nil, ip_address)
+
+      assert transaction = payment_method.purchase(purchase_amount, options)
       assert_equal purchase_amount, transaction.amount
       assert_equal "USD", transaction.currency_code
       assert_equal "Purchase", transaction.transaction_type
-      assert_equal ip_address, transaction.ip
+      assert_equal options[:ip_address], transaction.ip
+      assert_equal options[:order_id], transaction.order_id
+      assert_equal options[:description], transaction.description
+      assert_equal options[:merchant_name_descriptor], transaction.merchant_name_descriptor
+      assert_equal options[:merchant_location_descriptor], transaction.merchant_location_descriptor
+
+
+
       assert transaction.succeeded?
       transaction
     end

--- a/test/test_factory.rb
+++ b/test/test_factory.rb
@@ -9,7 +9,7 @@ module SpreedlyCore
   
     def given_a_purchase(purchase_amount=100, ip_address='127.0.0.1')
       payment_method = given_a_payment_method
-      assert transaction = payment_method.purchase(purchase_amount, nil, nil, ip_address=nil)
+      assert transaction = payment_method.purchase(purchase_amount, nil, nil, ip_address)
       assert_equal purchase_amount, transaction.amount
       assert_equal "USD", transaction.currency_code
       assert_equal "Purchase", transaction.transaction_type


### PR DESCRIPTION
Hi, this is meant to add the optional parameters that can be attached to the transaction (for example, merchant name and location as documented here https://core.spreedly.com/manual/payment-methods/using#specifying-a-custom-merchant-name-and-or-location)
